### PR TITLE
Update `sed` for 2024

### DIFF
--- a/buildrun.sh
+++ b/buildrun.sh
@@ -3,7 +3,7 @@
 java -jar prog8compiler-8.11-dev-all.jar -slowwarn -target cx16 pi.p8
 sed -i "/jsr  cx16.init_system_phase2/d" pi.asm
 sed -i "/jmp  cx16.cleanup_at_exit/d" pi.asm
-sed -ie "s/.word  (+), 2023/.word  (+), 0/" pi.asm
+sed -ie "s/.word  (+), 2024/.word  (+), 0/" pi.asm
 sed -ie "s/, \$3a, \$8f, '\ prog8'//" pi.asm
 
 sed -i "/src line:/d" pi.asm


### PR DESCRIPTION
Merge in 2024 to stop things breaking. Prog8's BASIC stub inserts the current year, so the script will need updating each year until a better solution is found.